### PR TITLE
Demo Gradio App

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Share your thoughts/samples/issues in our discord channel: https://discord.gg/HW
 - 2023-09-24: Add replicate demo (@nateraw); Fix error on windows, librosa warning etc (@ORI-Muchim).  
 - 2023-09-16: Fix DC shift issue. Fix duration padding bug. Update default DDIM steps to 50.
 
+## Gradio Demo
+
+To run the Gradio demo locally:
+
+1. Install dependencies: `pip install -r requirements.txt` 
+2. Run the app: `python app.py`
+3. Open the URL displayed to view the demo
+
 ## Commandline Usage
 
 ## Installation

--- a/app.py
+++ b/app.py
@@ -1,0 +1,29 @@
+import gradio as gr
+from audiosr import super_resolution, build_model
+
+def inference(audio_file, model_name, guidance_scale, ddim_steps):
+    audiosr = build_model(model_name=model_name)
+    
+    waveform = super_resolution(
+        audiosr,
+        audio_file,
+        guidance_scale=guidance_scale,
+        ddim_steps=ddim_steps
+    )
+    
+    return (44100, waveform)
+
+iface = gr.Interface(
+    fn=inference, 
+    inputs=[
+        gr.Audio(type="filepath", label="Input Audio"),
+        gr.Dropdown(["basic", "speech"], value="basic", label="Model"),
+        gr.Slider(1, 10, value=3.5, step=0.1, label="Guidance Scale"),  
+        gr.Slider(1, 100, value=50, step=1, label="DDIM Steps")
+    ],
+    outputs=gr.Audio(type="numpy", label="Output Audio"),
+    title="AudioSR",
+    description="Audio Super Resolution with AudioSR"
+)
+
+iface.launch()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cu118
 git+https://github.com/huggingface/diffusers.git
-git+https://github.com/huggingface/transformers.git
 torch==2.0.1+cu118; sys_platform != 'darwin'
 torch==2.0.1; sys_platform == 'darwin'
 torchvision==0.15.2+cu118; sys_platform != 'darwin'
@@ -9,3 +8,9 @@ torchaudio==2.0.2+cu118; sys_platform != 'darwin'
 torchaudio==2.0.2; sys_platform == 'darwin'
 huggingface_hub
 transformers==4.30.2
+gradio
+soundfile
+progressbar
+librosa
+audiosr
+unidecode


### PR DESCRIPTION
Testing Gradio as the Frontend. Code was written by Claude3 Opus with the following prompt:
> This repository is setup to include gradio, but there is no frontend configured. How would we add a gradio front-end to this repository as a pull request?

I had to swap out a few things in the requirements.txt file. I basically just copied any error from the terminal and asked Claude what to do next.

I was able to get the server running with the gradio interface on my local m1 macbook pro. It seems like it works. I uploaded a local mp3 file and, despite receiving a few warnings, was able to process the file. I played around with guidance and DDIM Steps and there is a noticeable difference when adjusting these settings.

Of course, I'm sure there are better ways of managing the dependencies and I have no idea if this works on other systems. And while my input test file was only 2 seconds, the output file always has an additional 4 seconds of silence 🤷 

Screenshots:
<img width="1302" alt="AudioSR 2024-04-27 19-24-32" src="https://github.com/haoheliu/versatile_audio_super_resolution/assets/297610/36aeb7fc-6f1f-4852-b2ba-0ca9777dc8e8">
<img width="1303" alt="AudioSR 2024-04-27 19-24-15" src="https://github.com/haoheliu/versatile_audio_super_resolution/assets/297610/8db59202-8630-4eb8-955e-bf8d54612cfd">
