### PR TITLE
Fix the conversion and output of mono audio

### DIFF
--- a/audiosr/utils.py
+++ b/audiosr/utils.py
@@ -309,6 +309,12 @@ def save_wave(waveform, inputpath, savepath, name="outwav", samplerate=16000):
 
         save_path = os.path.join(savepath, fname)
         temp_path = os.path.join(tempfile.gettempdir(), fname)
+        # Ensure the out file ends with .wav
+        if not temp_path.endswith('.wav'):
+            temp_path += '.wav'
+        if not save_path.endswith('.wav'):
+            save_path += '.wav'
+
         print("\033[98m {}\033[00m" .format("Don't forget to try different seeds by setting --seed <int> so that AudioSR can have optimal performance on your hardware."))
         print("Save audio to %s." % save_path)
         


### PR DESCRIPTION
For commit: 990d928033, we found that when converting mono audio files, `waveform[i]` was sometimes already an np.ndarray and this class does not have a `cpu()` method, leading to a `TypeError`. We added a check before conversion to prevent this issue.

For commit: 4ca8051bb9, we discovered that the output file path was not always ending with a .wav extension, which made both soundfile and ffmpeg unhappy. We added a check before the final output to ensure this issue does not occur.